### PR TITLE
Fix raygui build on windows, and indicate build commands in readme

### DIFF
--- a/README.org
+++ b/README.org
@@ -50,6 +50,17 @@ Tip: You can clone the [[https://github.com/bohonghuang/claw-raylib/tree/prebuil
                 (namestring (merge-pathnames (format nil "lib~A-adapter.so" lib) path))
                 (namestring (merge-pathnames (format nil "lib~A-adapter.~A.c" lib arch) path))))))
    #+END_SRC
+   If you use windows do \\
+   #+BEGIN_SRC lisp
+     (let ((arch "x86_64-pc-windows-gnu")
+           (path (merge-pathnames #P"lib/" (asdf:component-pathname (asdf:find-system '#:claw-raylib)))))
+       (dolist (lib '("raylib" "rlgl" "raygui"))
+         (uiop:run-program
+          (list "gcc" "-O3" "-fPIC" "-shared" "-o"
+                (namestring (merge-pathnames (format nil "lib~A-adapter.dll" lib) path))
+                (namestring (merge-pathnames (format nil "lib~A-adapter.~A.c" lib arch) path))
+                "-lraylib"))))
+   #+END_SRC 
 4. Load the system. \\
    #+BEGIN_SRC lisp
      (ql:quickload :claw-raylib)

--- a/lib/libraygui-adapter.x86_64-pc-windows-gnu.c
+++ b/lib/libraygui-adapter.x86_64-pc-windows-gnu.c
@@ -21,7 +21,13 @@
 #endif
 
 #ifdef _WIN32
-#  include <windows.h>
+#include <minwindef.h>
+#define GetModuleHandle GetModuleHandleA
+HMODULE GetModuleHandleA(LPCTSTR name);
+FARPROC GetProcAddress(
+  HMODULE hModule,
+  LPCSTR  lpProcName
+);
 static HMODULE ___claw_module;
 
 static int ___claw_init_wrapper() {


### PR DESCRIPTION
Hi!

I had some issues building the prebuild branch on windows. The two changes indicated in the PR fixed it for me:
1. I build on windows using msys2 gcc and had to tweak the command that built the binaries slightly.
2. I had some trouble building raygui due to some name collisions with windows stuff.

I don't know how much my experience relates to others trying to build on windows, but maybe they would find these changes helpful. 

Thank you for maintaining claw-raylib.

Tore